### PR TITLE
Optimize string creation

### DIFF
--- a/lib/UUID.pm6
+++ b/lib/UUID.pm6
@@ -22,18 +22,9 @@ class UUID {
     }
 
     method Str {
-        my $out;
-        $out ~= $.bytes[^4]>>.fmt("%02x").join;
-        $out ~= '-';
-        $out ~= $.bytes[4..^6]>>.fmt("%02x").join;
-        $out ~= '-';
-        $out ~= $.bytes[6..^8]>>.fmt("%02x").join;
-        $out ~= '-';
-        $out ~= $.bytes[8..^10]>>.fmt("%02x").join;
-        $out ~= '-';
-        $out ~= $.bytes[10..15]>>.fmt("%02x").join;
-
-        return $out;
+        (:256[$.bytes.values].fmt("%32.32x")
+            ~~ /(........)(....)(....)(....)(............)/)
+            .join("-");
     }
 
     method Blob {


### PR DESCRIPTION
Before:

```
> UUID.new().Str() for 1..10000; say now - INIT now;
105.496567
```

After:

```
> UUID.new().Str() for 1..10000; say now - INIT now;
19.1143763
```
